### PR TITLE
Properly handle querying the bits when the bits have not been set

### DIFF
--- a/error.go
+++ b/error.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	bitStateNotFoundStr = "Bit State Not Found"
+	bitStateNotFoundStr = "Failed to find bit state"
 )
 
 var (

--- a/error.go
+++ b/error.go
@@ -5,6 +5,10 @@ import (
 	"net/http"
 )
 
+const (
+	bitStateNotFoundStr = "Bit State Not Found"
+)
+
 var (
 	ErrBadRequest         = errors.New("bad request")
 	ErrUnauthorized       = errors.New("invalid or expired token")
@@ -14,7 +18,18 @@ var (
 	ErrServer             = errors.New("server error")
 	ErrServiceUnavailable = errors.New("service unavailable")
 	ErrUnknown            = errors.New("unknown error")
+	ErrBitStateNotFound = errors.New("bit state not found")
 )
+
+func newErrorForQuery(code int, body string) error {
+	if code != http.StatusOK {
+		return newError(code)
+	}
+	if body == bitStateNotFoundStr {
+		return ErrBitStateNotFound
+	}
+	return nil
+}
 
 func newError(code int) error {
 	switch code {

--- a/error.go
+++ b/error.go
@@ -18,7 +18,7 @@ var (
 	ErrServer             = errors.New("server error")
 	ErrServiceUnavailable = errors.New("service unavailable")
 	ErrUnknown            = errors.New("unknown error")
-	ErrBitStateNotFound = errors.New("bit state not found")
+	ErrBitStateNotFound   = errors.New("bit state not found")
 )
 
 func newErrorForQuery(code int, body string) error {

--- a/query.go
+++ b/query.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"net/http"
 	"strings"
 	"time"
 

--- a/query.go
+++ b/query.go
@@ -3,6 +3,7 @@ package devicecheck
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
@@ -46,7 +47,7 @@ func (t *Time) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// QueryTwoBits queries two bits for device token.
+// QueryTwoBits queries two bits for device token. Returns ErrBitStateNotFound if the bits have not been set.
 func (client *Client) QueryTwoBits(deviceToken string, result *QueryTwoBitsResult) error {
 	key, err := client.cred.key()
 	if err != nil {
@@ -70,8 +71,16 @@ func (client *Client) QueryTwoBits(deviceToken string, result *QueryTwoBitsResul
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("devicecheck: %w", newError(resp.StatusCode))
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	err = newErrorForQuery(resp.StatusCode, string(respBody))
+	if err == ErrBitStateNotFound {
+		return err
+	}
+	if err != nil {
+		return fmt.Errorf("devicecheck: %w", err)
 	}
 
 	return json.NewDecoder(resp.Body).Decode(result)

--- a/query.go
+++ b/query.go
@@ -1,6 +1,7 @@
 package devicecheck
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -82,5 +83,5 @@ func (client *Client) QueryTwoBits(deviceToken string, result *QueryTwoBitsResul
 		return fmt.Errorf("devicecheck: %w", err)
 	}
 
-	return json.NewDecoder(resp.Body).Decode(result)
+	return json.NewDecoder(bytes.NewReader(respBody)).Decode(result)
 }


### PR DESCRIPTION
Apple returns a bare string in the response with a 200 http code in this case. Since the master code only checks for error if the code is not 200, it will try to parse the bare string as json and die. The README states
> `// Note that SDK returns ErrBitStateNotFound error if no bits found`

This PR creates and returns that error.