### PR TITLE
Upgrade supported latest go version to 1.17, drop support for go 1.15

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go-version: [1.15.x, 1.16.x]
+        go-version: [1.16.x, 1.17.x]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.17.x
       - name: Generate coverage
         run: go test ./... -cover -coverprofile coverage.out -covermode atomic
       - name: Upload coverage

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rinchsan/device-check-go
 
-go 1.15
+go 1.16
 
 require (
 	github.com/dvsekhvalnov/jose2go v1.5.0

--- a/query.go
+++ b/query.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -72,7 +72,7 @@ func (client *Client) QueryTwoBits(deviceToken string, result *QueryTwoBitsResul
 	}
 	defer resp.Body.Close()
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("devicecheck: failed to read response body: %w", err)
 	}

--- a/query_test.go
+++ b/query_test.go
@@ -1,7 +1,7 @@
 package devicecheck
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -124,7 +124,7 @@ func TestClient_QueryTwoBits(t *testing.T) {
 			client: Client{
 				api: newAPIWithHTTPClient(newMockHTTPClient(&http.Response{
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(strings.NewReader("Failed to find bit state")),
+					Body:       io.NopCloser(strings.NewReader("Failed to find bit state")),
 				}), Development),
 				cred: NewCredentialFile("revoked_private_key.p8"),
 				jwt:  newJWT("issuer", "keyID"),
@@ -135,7 +135,7 @@ func TestClient_QueryTwoBits(t *testing.T) {
 			client: Client{
 				api: newAPIWithHTTPClient(newMockHTTPClient(&http.Response{
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(strings.NewReader(`{"bit0":true,"bit1":false,"last_update_time":"2006-01"}`)),
+					Body:       io.NopCloser(strings.NewReader(`{"bit0":true,"bit1":false,"last_update_time":"2006-01"}`)),
 				}), Development),
 				cred: NewCredentialFile("revoked_private_key.p8"),
 				jwt:  newJWT("issuer", "keyID"),

--- a/update.go
+++ b/update.go
@@ -2,7 +2,7 @@ package devicecheck
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -45,7 +45,7 @@ func (client *Client) UpdateTwoBits(deviceToken string, bit0, bit1 bool) error {
 	}
 	defer resp.Body.Close()
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("devicecheck: failed to read response body: %w", err)
 	}

--- a/update_test.go
+++ b/update_test.go
@@ -1,7 +1,7 @@
 package devicecheck
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -45,7 +45,7 @@ func TestClient_UpdateTwoBits(t *testing.T) {
 			client: Client{
 				api: newAPIWithHTTPClient(newMockHTTPClient(&http.Response{
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(strings.NewReader("success")),
+					Body:       io.NopCloser(strings.NewReader("success")),
 				}), Development),
 				cred: NewCredentialFile("revoked_private_key.p8"),
 				jwt:  newJWT("issuer", "keyID"),

--- a/validate.go
+++ b/validate.go
@@ -2,7 +2,7 @@ package devicecheck
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -41,7 +41,7 @@ func (client *Client) ValidateDeviceToken(deviceToken string) error {
 	}
 	defer resp.Body.Close()
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("devicecheck: failed to read response body: %w", err)
 	}

--- a/validate_test.go
+++ b/validate_test.go
@@ -1,7 +1,7 @@
 package devicecheck
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -45,7 +45,7 @@ func TestClient_ValidateDeviceToken(t *testing.T) {
 			client: Client{
 				api: newAPIWithHTTPClient(newMockHTTPClient(&http.Response{
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(strings.NewReader("success")),
+					Body:       io.NopCloser(strings.NewReader("success")),
 				}), Development),
 				cred: NewCredentialFile("revoked_private_key.p8"),
 				jwt:  newJWT("issuer", "keyID"),


### PR DESCRIPTION
- Upgrade supported latest go version and drop support for go 1.15
- Use io instead of deprecated ioutil
