### PR TITLE
Improve error Information

### DIFF
--- a/api.go
+++ b/api.go
@@ -60,7 +60,10 @@ func (api api) do(ctx context.Context, jwt, path string, requestBody interface{}
 
 	resp, err := api.client.Do(req)
 	if err != nil {
-		traceID := resp.Header.Get("x-b3-traceid")
+		var traceID string
+		if resp != nil {
+			traceID = resp.Header.Get("x-b3-traceid")
+		}
 		return 0, "", fmt.Errorf("http: %w: x-b3-traceid: %s", err, traceID)
 	}
 	defer resp.Body.Close()

--- a/api.go
+++ b/api.go
@@ -60,7 +60,8 @@ func (api api) do(ctx context.Context, jwt, path string, requestBody interface{}
 
 	resp, err := api.client.Do(req)
 	if err != nil {
-		return 0, "", fmt.Errorf("http: %w", err)
+		traceID := resp.Header.Get("x-b3-traceid")
+		return 0, "", fmt.Errorf("http: %w: x-b3-traceid: %s", err, traceID)
 	}
 	defer resp.Body.Close()
 

--- a/query.go
+++ b/query.go
@@ -72,7 +72,7 @@ func (client *Client) QueryTwoBits(ctx context.Context, deviceToken string, resu
 
 	code, respBody, err := client.api.do(ctx, jwt, queryTwoBitsPath, body)
 	if err != nil {
-		return fmt.Errorf("devicecheck: failed to query two bits: %w", err)
+		return fmt.Errorf("devicecheck: failed to query two bits: %w: %s", err, respBody)
 	}
 
 	if code != http.StatusOK {

--- a/update.go
+++ b/update.go
@@ -41,7 +41,7 @@ func (client *Client) UpdateTwoBits(ctx context.Context, deviceToken string, bit
 
 	code, respBody, err := client.api.do(ctx, jwt, updateTwoBitsPath, body)
 	if err != nil {
-		return fmt.Errorf("devicecheck: failed to update two bits: %w", err)
+		return fmt.Errorf("devicecheck: failed to update two bits: %w: %s", err, respBody)
 	}
 
 	if code != http.StatusOK {


### PR DESCRIPTION
I have included the information needed to contact Apple in the error message.

1. x-b3-traceid header
Required on Apple form.
<img width="463" alt="image" src="https://github.com/rinchsan/device-check-go/assets/1576894/cf329d2e-05ff-447c-a955-d440ae6f82fd">

```go
traceID := resp.Header.Get("x-b3-traceid")
return 0, "", fmt.Errorf("http: %w: x-b3-traceid: %s", err, traceID)
```

2. full response
I added full response because it seems that they generally want full response information in addition to transaction_id, device_token etc.

```go
return fmt.Errorf("devicecheck: failed to query two bits: %w: %s", err, respBody)
```